### PR TITLE
increase CURL_MAX_WRITE_SIZE 32x

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -179,7 +179,7 @@ typedef int (*curl_xferinfo_callback)(void *clientp,
      time for those who feel adventurous. The practical minimum is about
      400 bytes since libcurl uses a buffer of this size as a scratch area
      (unrelated to network send operations). */
-#define CURL_MAX_WRITE_SIZE 16384
+#define CURL_MAX_WRITE_SIZE 524288 /* = 32 * 16384 (the default) */
 #endif
 
 #ifndef CURL_MAX_HTTP_HEADER


### PR DESCRIPTION
- help upload performance
- curl-library Archive - Slow Upload Performance on High-Bandwidth connections on windows
  - http://curl.haxx.se/mail/lib-2013-02/0009.html
- libssh2-devel archive - Libssh2 usage from cURL with various buffer sizes
  - http://www.libssh2.org/mail/libssh2-devel-archive-2011-11/0019.shtml
