### PR TITLE
externpro 25.07.4-37-g0c49de2

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -4,9 +4,9 @@ permissions:
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["v*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.2
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.2
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.2
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.2
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,14 @@
+name: Tag Release
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@main
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-37-g0c49de2`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-37-g0c49de2`
- Previous HEAD: `b085e5e2397d87756f6a026138ae82e5740f0406`
- New HEAD: `0c49de2d3b041e4e081ae2203158bc85999d88e2`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.2 → 25.07.4
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template
✓ xprelease.yml: Version updated 25.07.2 → 25.07.4
✓ xptag.yml: Created new workflow from template


---

*This PR was created automatically by GitHub Actions*
